### PR TITLE
Do not add src/ to sysroot crates' paths, they already have it now.

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -99,8 +99,7 @@ impl AnalysisLoader for CargoAnalysisLoader {
             .join("lib")
             .join("rustlib")
             .join("src")
-            .join("rust")
-            .join("src");
+            .join("rust");
 
         vec![
             SearchDirectory::new(libs_path, Some(src_path)),


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/53586, source paths include `src/`, e.g. `src/libcore/iter/traits.rs`.
Needed for fixing https://github.com/rust-lang/rls/issues/1140.